### PR TITLE
Add project_id query param to GET palettes

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -48,7 +48,12 @@ app.get("/api/v1/projects", (req, res) => {
 });
 
 app.get("/api/v1/palettes", (req, res) => {
+  const { project_id } = req.query;
+  console.log(project_id);
   database("palettes")
+    .modify((queryBuilder) => {
+      project_id && queryBuilder.where({ project_id });
+    })
     .select()
     .then(palettes => {
       res.status(200).json(palettes);

--- a/server/app.js
+++ b/server/app.js
@@ -49,7 +49,6 @@ app.get("/api/v1/projects", (req, res) => {
 
 app.get("/api/v1/palettes", (req, res) => {
   const { project_id } = req.query;
-  console.log(project_id);
   database("palettes")
     .modify((queryBuilder) => {
       project_id && queryBuilder.where({ project_id });

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -54,6 +54,21 @@ describe("Server", () => {
       expect(res.status).toEqual(200);
       expect(palettes.length).toEqual(expectedPalettes.length);
     });
+
+    it("should query results by project_id if the param is included", async () => {
+      const { id } = await database('projects').first().select('id');
+      const expectedPalettes = await database("palettes")
+        .where({ project_id: id })
+        .select();
+
+      const res = await request(app).get(
+        `/api/v1/palettes?project_id=${id}`
+      );
+      const palettes = res.body;
+
+      expect(res.status).toEqual(200);
+      expect(palettes.length).toEqual(expectedPalettes.length);
+    });
   });
 
   describe("GET /projects/:id", () => {


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Add the query param of project_id so we can search for a projects associated palettes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:

# Message for reviewer:
Let me know if you have any questions about how this was implemented, in particular the modify method.


# Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas


Co-authored-by: B-Coyle <bacoyle0409@gmail.com>
Co-authored-by: jacobogart <jacobogart@gmail.com>